### PR TITLE
docs.yml: bump Node 20 -> 22 for pnpm 11

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
           cache-dependency-path: docs-next/pnpm-lock.yaml
 


### PR DESCRIPTION
## Summary
- Follow-up to [#27](https://github.com/packetThrower/PortFinder/pull/27). The Docs workflow on `main` is failing because pnpm 11 requires Node ≥22.13, but the workflow installed Node 20 — `setup-pnpm` crashed with `ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite`.
- One-line fix: bump `node-version: 20` → `22`.

## Test plan
- [ ] Docs workflow `build` job goes green on this PR
- [ ] After merge, Docs workflow on `main` runs `deploy` and the new Starlight site goes live at https://packetthrower.github.io/PortFinder/

🤖 Generated with [Claude Code](https://claude.com/claude-code)