### PR TITLE
docs-next: prefix internal links with /PortFinder/ base

### DIFF
--- a/docs-next/astro.config.mjs
+++ b/docs-next/astro.config.mjs
@@ -28,7 +28,7 @@ export default defineConfig({
 				},
 			],
 			editLink: {
-				baseUrl: 'https://github.com/packetThrower/PortFinder/edit/main/docs-next/src/content/docs/',
+				baseUrl: 'https://github.com/packetThrower/PortFinder/edit/main/docs-next/',
 			},
 			sidebar: [
 				{ label: 'Install', slug: 'install' },

--- a/docs-next/src/content/docs/404.mdx
+++ b/docs-next/src/content/docs/404.mdx
@@ -7,11 +7,11 @@ hero:
   tagline: "Most things still live at predictable URLs. Try one below."
   actions:
     - text: Back to docs
-      link: /
+      link: /PortFinder/
       icon: right-arrow
       variant: primary
     - text: Install
-      link: /install/
+      link: /PortFinder/install/
       variant: secondary
     - text: View on GitHub
       link: https://github.com/packetThrower/PortFinder
@@ -21,8 +21,8 @@ hero:
 
 If you got here from an external link that used to point at the old MkDocs site, the URL probably moved. Most things still live at predictable paths:
 
-- [Install](/install/) — package manager and manual paths
-- [GUI usage](/usage/gui/) — the desktop app
-- [CLI usage](/usage/cli/) — the headless `portfinder` binary
-- [Architecture](/dev/architecture/) — Tauri shell, Rust backend, libpcap
-- [Changelog](/changelog/)
+- [Install](/PortFinder/install/) — package manager and manual paths
+- [GUI usage](/PortFinder/usage/gui/) — the desktop app
+- [CLI usage](/PortFinder/usage/cli/) — the headless `portfinder` binary
+- [Architecture](/PortFinder/dev/architecture/) — Tauri shell, Rust backend, libpcap
+- [Changelog](/PortFinder/changelog/)

--- a/docs-next/src/content/docs/index.mdx
+++ b/docs-next/src/content/docs/index.mdx
@@ -6,7 +6,7 @@ hero:
   tagline: Plug a laptop into a switch, see what port you're on, in under thirty seconds.
   actions:
     - text: Install for your platform
-      link: /install/
+      link: /PortFinder/install/
       icon: right-arrow
       variant: primary
     - text: View on GitHub
@@ -39,9 +39,9 @@ The same release ships a desktop app and a headless CLI. Pick the one that fits 
 
 <CardGrid>
   <Card title="Desktop GUI" icon="laptop">
-    Native widgets per platform: macOS, Windows, Linux. [GUI usage →](/usage/gui/)
+    Native widgets per platform: macOS, Windows, Linux. [GUI usage →](/PortFinder/usage/gui/)
   </Card>
   <Card title="Headless CLI" icon="seti:powershell">
-    `portfinder capture --interface en0 --protocol LLDP --json`. [CLI usage →](/usage/cli/)
+    `portfinder capture --interface en0 --protocol LLDP --json`. [CLI usage →](/PortFinder/usage/cli/)
   </Card>
 </CardGrid>

--- a/docs-next/src/content/docs/install.mdx
+++ b/docs-next/src/content/docs/install.mdx
@@ -25,7 +25,7 @@ Pre-built binaries for every release live on the [Releases page](https://github.
 brew install --cask packetThrower/tap/portfinder
 ```
 
-This installs `PortFinder.app` to `/Applications` and symlinks the headless CLI to `$(brew --prefix)/bin/portfinder` so [`portfinder`](/usage/cli/) works from any shell. Update with `brew upgrade --cask portfinder`; remove with `brew uninstall --cask portfinder` (add `--zap` to also clear `~/Library/Application Support/PortFinder` and the WebKit cache).
+This installs `PortFinder.app` to `/Applications` and symlinks the headless CLI to `$(brew --prefix)/bin/portfinder` so [`portfinder`](/PortFinder/usage/cli/) works from any shell. Update with `brew upgrade --cask portfinder`; remove with `brew uninstall --cask portfinder` (add `--zap` to also clear `~/Library/Application Support/PortFinder` and the WebKit cache).
 
 The tap source lives at [packetThrower/homebrew-tap](https://github.com/packetThrower/homebrew-tap), shared with [Baudrun](https://github.com/packetThrower/Baudrun) and other packetThrower projects.
 
@@ -58,7 +58,7 @@ For non-root capture and a `portfinder` CLI on your `PATH`, also install the BPF
 2. Double-click to install. macOS will prompt for your password.
 3. Click **Install BPF Access** in the app the first time you run it (or re-run the `.pkg`).
 
-The BPF helper drops a symlink at `/usr/local/bin/portfinder` so the [CLI](/usage/cli/) is callable from any shell.
+The BPF helper drops a symlink at `/usr/local/bin/portfinder` so the [CLI](/PortFinder/usage/cli/) is callable from any shell.
 </details>
 
 <details>
@@ -88,7 +88,7 @@ scoop bucket add packetThrower https://github.com/packetThrower/scoop-bucket
 scoop install portfinder
 ```
 
-This installs `PortFinder.exe`, drops a Start menu shortcut, and exposes the headless CLI on your `PATH` so [`portfinder`](/usage/cli/) works from any shell. Update with `scoop update portfinder`; uninstall with `scoop uninstall portfinder`. The bucket source lives at [packetThrower/scoop-bucket](https://github.com/packetThrower/scoop-bucket).
+This installs `PortFinder.exe`, drops a Start menu shortcut, and exposes the headless CLI on your `PATH` so [`portfinder`](/PortFinder/usage/cli/) works from any shell. Update with `scoop update portfinder`; uninstall with `scoop uninstall portfinder`. The bucket source lives at [packetThrower/scoop-bucket](https://github.com/packetThrower/scoop-bucket).
 
 You still need [Npcap](https://npcap.com/#download) for packet capture — Scoop can't bundle the kernel driver.
 


### PR DESCRIPTION
## Summary
On the deployed site (`https://packetthrower.github.io/PortFinder/`), several internal links 404'd because they were written as `/install/`, `/usage/gui/`, etc. without the `/PortFinder/` base prefix. Starlight's auto-prefix didn't catch them in three contexts:

- Hero action `link:` values in frontmatter (`index.mdx`, `404.mdx`)
- Links inside `<Card>` component slots (`index.mdx`)
- Inline body links on `template: splash` pages (`404.mdx`)
- Inline body links across regular pages (`install.mdx` — `[`portfinder`](/usage/cli/)`)

Fix: hardcode `/PortFinder/...` on every internal absolute link.

Bonus: `astro.config.mjs` had `editLink.baseUrl` double-pathing `src/content/docs/`, producing edit URLs like `.../src/content/docs/src/content/docs/index.mdx`. Trimmed to just the repo root + branch.

Verified locally with `pnpm build` — every link in the built `dist/` HTML now resolves under `/PortFinder/`.

## Test plan
- [ ] CI `Docs / build` job passes on this PR
- [ ] After merge, smoke-check the live site:
  - [ ] Landing page CTAs ("Install for your platform", "GUI usage", "CLI usage" cards)
  - [ ] 404 page CTAs and rescue-link list
  - [ ] Install page inline links to `[CLI](/PortFinder/usage/cli/)`
  - [ ] Edit link in any page footer points to a real GitHub edit URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)