### PR TITLE
docs-next: add screenshots to GUI + CLI pages

### DIFF
--- a/docs-next/src/content/docs/usage/cli.mdx
+++ b/docs-next/src/content/docs/usage/cli.mdx
@@ -5,6 +5,8 @@ description: The same binary works headless. Capture, list, or diagnose privileg
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
+![portfinder running in a terminal](/PortFinder/screenshots/cli.png)
+
 The same binary works headless — pass a subcommand to use the CLI, run with no args to launch the GUI.
 
 ```bash

--- a/docs-next/src/content/docs/usage/gui.mdx
+++ b/docs-next/src/content/docs/usage/gui.mdx
@@ -3,6 +3,8 @@ title: GUI
 description: Pick an interface, pick a protocol, click Start. Read the result.
 ---
 
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
 ![PortFinder showing a captured LLDP packet](/PortFinder/screenshots/macos-result.png)
 
 ## Workflow
@@ -11,6 +13,28 @@ description: Pick an interface, pick a protocol, click Start. Read the result.
 2. **Pick the protocol.** **LLDP** is the universal choice (Aruba, HP, Juniper, Extreme, Cisco, and MikroTik when you've enabled it). **CDP** is Cisco-only. **MNDP** is the MikroTik-only fallback for RouterOS devices that ship with `discovery-protocol = mndp` and never speak LLDP.
 3. **Click Start.** Most switches send a discovery packet every 30–60 seconds, so it usually takes a few seconds for the first frame to arrive.
 4. **Read the result.** Switch name, IP, port, VLAN, voice VLAN, MTU, and model populate the result card.
+
+## On each platform
+
+Native widgets per platform — same workflow, different chrome.
+
+<Tabs>
+<TabItem label="macOS">
+
+![PortFinder on macOS](/PortFinder/screenshots/macos.png)
+
+</TabItem>
+<TabItem label="Windows">
+
+![PortFinder on Windows](/PortFinder/screenshots/windows.png)
+
+</TabItem>
+<TabItem label="Linux">
+
+![PortFinder on Linux](/PortFinder/screenshots/linux.png)
+
+</TabItem>
+</Tabs>
 
 ## Privilege warnings
 


### PR DESCRIPTION
## Summary
- **GUI page** only had the result-card hero shot. Added an "On each platform" section with a Tabs block showing `macos.png` / `windows.png` / `linux.png` so users can see the native chrome before installing.
- **CLI page** had no screenshot at all. Added `cli.png` at the top, right before the intro paragraph.

All five screenshots already shipped in `docs-next/public/screenshots/` from the original replatform PR (carried over from `docs/assets/screenshots/`); this PR just references them.

## Test plan
- [ ] CI `Docs / build` passes
- [ ] After merge, smoke-check the live site:
  - [ ] `usage/gui/` shows the result hero, then the Tabs block with 3 platform shots
  - [ ] `usage/cli/` shows `cli.png` at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)