### PR TITLE
docs-next: drop blank header shot from GUI page

### DIFF
--- a/docs-next/src/content/docs/usage/gui.mdx
+++ b/docs-next/src/content/docs/usage/gui.mdx
@@ -5,8 +5,6 @@ description: Pick an interface, pick a protocol, click Start. Read the result.
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-![PortFinder showing a captured LLDP packet](/PortFinder/screenshots/macos-result.png)
-
 ## Workflow
 
 1. **Pick an interface.** The dropdown shows every NIC on your machine. Use the toggle to hide interfaces with no IP. Hit the ↻ button to re-scan after plugging or unplugging cables.


### PR DESCRIPTION
## Summary
The `macos-result.png` referenced at the top of `usage/gui/` is still the 355-byte placeholder solid-navy block from `docs/assets/screenshots/` (per its own README.txt). It renders as a big empty rectangle. Pulling it; the per-platform Tabs gallery below has the real captures, so the page still reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)