### PR TITLE
docs-next: add robots.txt pointing at the sitemap

### DIFF
--- a/docs-next/public/robots.txt
+++ b/docs-next/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://packetthrower.github.io/PortFinder/sitemap-index.xml


### PR DESCRIPTION
## Summary
The sitemap is already generated by `@astrojs/sitemap` (Starlight default) and served at `/PortFinder/sitemap-index.xml`. Adding a `robots.txt` so Google and other crawlers can discover it via the standard `/robots.txt` path.

```
User-agent: *
Allow: /

Sitemap: https://packetthrower.github.io/PortFinder/sitemap-index.xml
```

After merge, `https://packetthrower.github.io/robots.txt` will return 200 and reference the absolute sitemap URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)