### PR TITLE
after_release: fix dead release trigger (winget PR never auto-fired)

### DIFF
--- a/.github/workflows/after_release.yml
+++ b/.github/workflows/after_release.yml
@@ -1,18 +1,25 @@
 name: After Release
 
-# Fires after a GitHub Release has been published by release.yml's `release`
-# job (which uses softprops/action-gh-release on tag-push). Separate workflow
+# Fires after release.yml completes on a tag push. Separate workflow
 # from release.yml so the release job stays focused on building + uploading
 # artifacts; post-release publishing — currently the winget submission, more
 # in the future — lives here.
 #
+# `workflow_run`, NOT `release: published`: release.yml publishes the
+# Release with the default GITHUB_TOKEN, and GitHub suppresses events
+# created by that token from triggering other workflows (recursion
+# guard) — a `release` trigger here never fires. `workflow_run` events
+# are exempt from that suppression. For a tag-push run, the tag name
+# arrives as `workflow_run.head_branch`.
+#
 # The workflow_dispatch trigger lets us manually re-run a winget submission
-# if the release-event-triggered run flakes (rare but documented in the
+# if the auto-triggered run flakes (rare but documented in the
 # winget-pkgs validator history).
 on:
-  release:
+  workflow_run:
+    workflows: [Release]
     types:
-      - published
+      - completed
   workflow_dispatch:
     inputs:
       tag_name:
@@ -39,14 +46,25 @@ jobs:
     # WINGET_TOKEN secret won't be set on a fork anyway, but failing fast
     # with a clean skip is friendlier than a mid-action 401.
     #
-    # Skip on pre-releases — the manifest schema's `ProductVersion` field
-    # rejects alphanumeric segments (`-beta.N`), MSI builds are skipped
-    # for pre-release tags by release.yml's existing `contains('-')` gate
-    # anyway, and winget itself has no pre-release channel. Stable only.
+    # On the workflow_run path: only after a SUCCESSFUL Release run, and
+    # only for tag-push runs (head_branch = the tag, e.g. `v4.1.4`) —
+    # release.yml also has a workflow_dispatch trigger whose runs carry
+    # a plain branch name here.
+    #
+    # Skip on pre-releases (tag contains `-`) — the manifest schema's
+    # `ProductVersion` field rejects alphanumeric segments (`-beta.N`),
+    # MSI builds are skipped for pre-release tags by release.yml's
+    # existing `contains('-')` gate anyway, and winget itself has no
+    # pre-release channel. Stable only.
     if: >-
       github.repository_owner == 'packetThrower' &&
       (
-        (github.event_name == 'release' && !github.event.release.prerelease) ||
+        (
+          github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          startsWith(github.event.workflow_run.head_branch, 'v') &&
+          !contains(github.event.workflow_run.head_branch, '-')
+        ) ||
         (github.event_name == 'workflow_dispatch' && !contains(inputs.tag_name, '-'))
       )
     steps:
@@ -87,8 +105,9 @@ jobs:
       #
       # `identifier`: the PackageIdentifier our manifest declares
       # (`packaging/windows/winget/packetThrower.PortFinder.installer.yaml.template`).
-      # `release-tag`: drawn from the triggering Release on the auto-
-      # fire path, from the dispatch input on the manual path.
+      # `release-tag`: the tag that triggered the Release run on the
+      # auto-fire path (workflow_run.head_branch carries the tag for
+      # tag-push runs), the dispatch input on the manual path.
       # `max-versions-to-keep`: bounds the per-version directories in
       # `microsoft/winget-pkgs/manifests/p/packetThrower/PortFinder/` so
       # the tree doesn't accumulate every historical version. 5 gives
@@ -108,7 +127,7 @@ jobs:
         uses: vedantmgoyal9/winget-releaser@7bd472be23763def6e16bd06cc8b1cdfab0e2fd5 # v2
         with:
           identifier: packetThrower.PortFinder
-          release-tag: ${{ github.event.release.tag_name || inputs.tag_name }}
+          release-tag: ${{ github.event.workflow_run.head_branch || inputs.tag_name }}
           max-versions-to-keep: 5
           installers-regex: '\.msi$'
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
## Summary
The winget submission never fired automatically: release.yml publishes the Release with the default `GITHUB_TOKEN`, and GitHub suppresses events created by that token from triggering other workflows (recursion guard). The `release: published` trigger in after_release.yml was dead code — 4.1.3 and 4.1.4 were both submitted via manual `workflow_dispatch`.

Fix: trigger on `workflow_run` (Release, completed) instead — exempt from the suppression. Tag comes from `workflow_run.head_branch` (the tag name on tag-push runs). Job guard now requires: successful Release conclusion, `v`-prefixed head_branch (filters out release.yml's own workflow_dispatch runs, which carry a branch name), no hyphen (stable only, as before).

Manual `workflow_dispatch` path is unchanged as the fallback.

## Test plan
- [ ] Merge, then verify on the next stable tag that "After Release" fires without a manual dispatch
- [x] v4.1.4 winget submission already done via manual dispatch (run 29439023228, success)

🤖 Generated with [Claude Code](https://claude.com/claude-code)